### PR TITLE
update documentation for clarity 

### DIFF
--- a/docs/src/usage/stages.md
+++ b/docs/src/usage/stages.md
@@ -30,8 +30,8 @@ def load_image(path):
 def classify(x):
     # [...] lookup the most likely class
     return class
-
-my_classifier_transform = (
+    
+my_classifier = (
     load_image                 # preprocessing ...
     >> transforms.ToTensor()   # 
     >> batch                   # ... stage


### PR DESCRIPTION
Expected:
my_classifier refers to pipeline defined in previous code block

Actual:
different naming of my_classifier and my_classifier_transform imply that these are different objects (or would have this effect, in practice), making it confusing as to the type of my_classifier

Fix:
Made naming consistent. alternatively, both could be renamed to my_classifier_pipeline to make this explicit

<!-- Thank you for your contribution! -->

## Description
<!-- Provide a brief description of the PR's purpose here. -->
Fixes #\<issue_number>
